### PR TITLE
85 calloutdetails view should not display route all the time

### DIFF
--- a/src/components/CalloutDetails.tsx
+++ b/src/components/CalloutDetails.tsx
@@ -1,12 +1,19 @@
+import { Wrapper } from '@googlemaps/react-wrapper';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import { Col, Row } from 'react-bootstrap';
+import { Marker, Map } from '../pages/Customer/CustomerConfirmLocation';
 import MechanicViewRoute from './MechanicViewRoute';
-import Auth from './utils/Auth';
 import {formatDate, formatTime} from "./utils/Helpers";
 
 interface CalloutDetailsProps {
     details: CalloutDetailsInterface,
     displayRoute: boolean,
 }
+
+const render = (status: any) => {
+    return <h1>{status}</h1>;
+  };
 
 export interface CalloutDetailsInterface {
     id: number,
@@ -21,7 +28,26 @@ export interface CalloutDetailsInterface {
 }
 
 const CalloutDetails = (props: CalloutDetailsProps) => {
+    const [location, setLocation] = useState<any>(null);
+    
     let details = props.details;
+
+    const getLatLng = () => {
+        if(details.location != ""){
+            axios.get(`https://maps.googleapis.com/maps/api/geocode/json?address=${details.location}&key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}`).then(
+                (response: any) => {
+                    console.log("Google Geocode API response: ");
+                    console.log(response.data)
+                    console.log(response.data.results[0].geometry.location);
+                    setLocation(response.data.results[0].geometry.location);
+                }
+                );
+        }
+    }
+
+    useEffect(() => {
+        getLatLng();
+    }, [details])
 
     return (
         <>
@@ -34,16 +60,25 @@ const CalloutDetails = (props: CalloutDetailsProps) => {
             <MechanicViewRoute destination={details.location}
             googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`}
             loadingElement={<div style={{ height: `100%` }} />}
-            containerElement={<div style={{ height: `400px` }} />}
+            containerElement={<div style={{ paddingLeft: `5%`, paddingRight: `5%`, height: `400px` }} />}
             mapElement={<div style={{ height: `100%` }} />}/>
         ) : (
-            <>TODO [optional]: display a marker of location</>
+            <div style={{ paddingLeft: "5%", paddingRight: "5%", height: "100%" }}>
+                <Wrapper apiKey={`${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}`} render={render}>
+                    {location ? (
+                        <Map
+                        center={location}
+                        zoom={18}
+                        style={{height: "400px" }}
+                        >
+                            <Marker position={location} />
+                        </Map>
+                    ) : (
+                        <></>
+                    )}
+                </Wrapper>
+            </div>
         )}
-        {/* <MechanicViewRoute destination={details.location}
-            googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`}
-            loadingElement={<div style={{ height: `100%` }} />}
-            containerElement={<div style={{ height: `400px` }} />}
-            mapElement={<div style={{ height: `100%` }} />}/> */}
         <div id="map"></div>
         <div style={{paddingLeft: "10%", paddingRight: "10%", paddingBottom: "2em"}}>
             <h3 style={{textAlign: "left"}}>JOB DETAILS</h3>

--- a/src/components/CalloutDetails.tsx
+++ b/src/components/CalloutDetails.tsx
@@ -4,7 +4,8 @@ import Auth from './utils/Auth';
 import {formatDate, formatTime} from "./utils/Helpers";
 
 interface CalloutDetailsProps {
-    details: CalloutDetailsInterface;
+    details: CalloutDetailsInterface,
+    displayRoute: boolean,
 }
 
 export interface CalloutDetailsInterface {
@@ -16,7 +17,7 @@ export interface CalloutDetailsInterface {
     mechanic: string, 
     date: string, 
     rating: string, 
-    review: string
+    review: string,
 }
 
 const CalloutDetails = (props: CalloutDetailsProps) => {
@@ -29,7 +30,7 @@ const CalloutDetails = (props: CalloutDetailsProps) => {
         <h4>$200.00</h4>
         {/* only should display route when mechanic is viewing and/or 
         actually working on the job. */}
-        {/* {(Auth.isMechanic() && (details.status == "PENDING" || details.status == "ACCEPTED")) ? (
+        {props.displayRoute ? (
             <MechanicViewRoute destination={details.location}
             googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`}
             loadingElement={<div style={{ height: `100%` }} />}
@@ -37,12 +38,12 @@ const CalloutDetails = (props: CalloutDetailsProps) => {
             mapElement={<div style={{ height: `100%` }} />}/>
         ) : (
             <>TODO [optional]: display a marker of location</>
-        )} */}
-        <MechanicViewRoute destination={details.location}
+        )}
+        {/* <MechanicViewRoute destination={details.location}
             googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`}
             loadingElement={<div style={{ height: `100%` }} />}
             containerElement={<div style={{ height: `400px` }} />}
-            mapElement={<div style={{ height: `100%` }} />}/>
+            mapElement={<div style={{ height: `100%` }} />}/> */}
         <div id="map"></div>
         <div style={{paddingLeft: "10%", paddingRight: "10%", paddingBottom: "2em"}}>
             <h3 style={{textAlign: "left"}}>JOB DETAILS</h3>

--- a/src/components/MechanicViewRoute.tsx
+++ b/src/components/MechanicViewRoute.tsx
@@ -12,33 +12,10 @@ interface MapRoutesProps {
   destination: any;
 }
 
-const MapRoutes = ({ origin, destination }: MapRoutesProps) => {
-  const [directions, setDirections] = useState<any>();
-
-  const directionsService = new google.maps.DirectionsService();
-
-  useEffect(() => {
-    directionsService.route(
-      {
-        origin: origin,
-        destination: destination,
-        travelMode: google.maps.TravelMode.DRIVING,
-      },
-      (result, status) => {
-        console.log(result);
-        if (status === google.maps.DirectionsStatus.OK) {
-          setDirections(result);
-        } else {
-          setDirections(result);
-          console.log(result);
-        }
-      }
-    );
-  }, []);
-
+const MapRoutes = ({ directions }: any) => {
   return (
     <DirectionsRenderer
-      options={{suppressMarkers: true}}
+      options={{suppressMarkers: false}}
       directions={directions}
     />
   );
@@ -46,24 +23,49 @@ const MapRoutes = ({ origin, destination }: MapRoutesProps) => {
 
 const SomeMap = withScriptjs(withGoogleMap(({destination}: any) => {
   const [origin, setOrigin] = useState<google.maps.LatLng>(new google.maps.LatLng(0, 0));
+  const [directions, setDirections] = useState<any>();
+
+  const directionsService = new google.maps.DirectionsService();
 
   useEffect(() => {
     if ("geolocation" in navigator) {
         console.log("Available");
+
+        let latlng = new google.maps.LatLng(0, 0);
+
         navigator.geolocation.getCurrentPosition(function(position) {
             console.log("Latitude is :", position.coords.latitude);
             console.log("Longitude is :", position.coords.longitude);
             
-            const latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
+            latlng = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
 
             setOrigin(latlng);
-          });
+
+            if(destination != ""){
+              directionsService.route(
+                {
+                  origin: latlng,
+                  destination: destination,
+                  travelMode: google.maps.TravelMode.DRIVING,
+                },
+                (result, status) => {
+                  console.log(result);
+                  if (status === google.maps.DirectionsStatus.OK) {
+                    setDirections(result);
+                  } else {
+                    // setDirections(result);
+                    console.log(result);
+                  }
+                });
+              }
+            }
+          );
     } else {
         console.log("Not Available");
         // TODO: add a notification reccomending user to enable 
         // location services in the browser
     }
-  }, []);
+  }, [destination]);
 
     return (
       <div style={{ display: "flex", height: "100%" }}>
@@ -71,13 +73,11 @@ const SomeMap = withScriptjs(withGoogleMap(({destination}: any) => {
           center={origin}
           zoom={18}
         >
-          {(origin && destination != "") ? (
+          {(directions != null) ? (
             <>
             <MapRoutes 
-            origin={origin}
-            destination={destination}
+            directions={directions}
             />
-            <Marker position={origin}/>
             </>
           ) : (
               <></>

--- a/src/pages/Customer/CustomerConfirmLocation.tsx
+++ b/src/pages/Customer/CustomerConfirmLocation.tsx
@@ -53,6 +53,7 @@ const CustomerConfirmLocation = ({ setLocation }: any) => {
     axios.get(`https://maps.googleapis.com/maps/api/geocode/json?latlng=${click[0].lat().toString()},${click[0].lng().toString()}&key=${process.env.REACT_APP_GOOGLE_MAPS_API_KEY}`)
         .then(
           response => {
+            console.log("Google geocode API response:");
             console.log(response.data);
             console.log(response.data.results[0].formatted_address);
             setLocation(response.data.results[0].formatted_address);
@@ -141,7 +142,7 @@ export const Map: React.FC<MapProps> = ({
   );
 };
 
-const Marker: React.FC<google.maps.MarkerOptions> = (options) => {
+export const Marker: React.FC<google.maps.MarkerOptions> = (options) => {
   const [marker, setMarker] = React.useState<google.maps.Marker>();
 
   React.useEffect(() => {

--- a/src/pages/General/CalloutHistoryDetails.tsx
+++ b/src/pages/General/CalloutHistoryDetails.tsx
@@ -48,7 +48,7 @@ const RequestDetails = () => {
 
     return (
         <>
-        <CalloutDetails details={details}/>
+        <CalloutDetails displayRoute={false} details={details}/>
         </>
     );
 };

--- a/src/pages/Professional/MechanicCurrentJob.tsx
+++ b/src/pages/Professional/MechanicCurrentJob.tsx
@@ -28,10 +28,12 @@ const CurrentJob = (props: any) => {
 
     return (
         <>
-            <CalloutDetails details={props.request}/>
-            <form onSubmit={markAsComplete}>
-                <button type="submit" className="btn btn-primary btn-block">Mark as Complete</button>
-            </form>
+            <CalloutDetails displayRoute={true} details={props.request}/>
+            <div style={{padding:"2em"}}>
+                <form onSubmit={markAsComplete}>
+                    <button type="submit" className="btn btn-primary btn-block">Mark as Complete</button>
+                </form>
+            </div>
         </>
     );
 }

--- a/src/pages/Professional/RequestDetails.tsx
+++ b/src/pages/Professional/RequestDetails.tsx
@@ -81,7 +81,7 @@ const RequestDetails = () => {
 
     return (
         <>
-        <CalloutDetails details={details}/>
+        <CalloutDetails displayRoute={true} details={details}/>
         <form onSubmit={acceptJob}>
         <button type="submit" className="btn-primary btn">Accept this callout</button>
         </form>


### PR DESCRIPTION
CalloutDetails now either shows (depending on the app-state): 
1) A single marker for where the callout was called from.
2) A route from the user (mechanic) to the callout location.